### PR TITLE
Rename attribute to fix duplicate

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -241,7 +241,7 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
         if (drawableVertical != null) {
             setDividerDrawableVertical(drawableVertical);
         }
-        int dividerMode = a.getInt(R.styleable.FlexboxLayout_showDivider, SHOW_DIVIDER_NONE);
+        int dividerMode = a.getInt(R.styleable.FlexboxLayout_showDividerVisibility, SHOW_DIVIDER_NONE);
         if (dividerMode != SHOW_DIVIDER_NONE) {
             mShowDividerVertical = dividerMode;
             mShowDividerHorizontal = dividerMode;

--- a/flexbox/src/main/res/values/attrs.xml
+++ b/flexbox/src/main/res/values/attrs.xml
@@ -64,7 +64,7 @@ limitations under the License.
         <attr name="dividerDrawableHorizontal" format="reference" />
         <attr name="dividerDrawableVertical" format="reference" />
 
-        <attr name="showDivider">
+        <attr name="showDividerVisibility">
             <flag name="none" value="0" />
             <flag name="beginning" value="1" />
             <flag name="middle" value="2" />


### PR DESCRIPTION
rename `showDivider` to `showDividerVisibility` to fix duplicate attributes